### PR TITLE
Allow platform argument to be substituted for a 2char lang

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,3 @@
 CROWDIN_KEY=somekey
+GIT_REMOTE=origin
+GIT_HEAD=master

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+CROWDIN_KEY=somekey

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 ### Phalcon template
 /cache/
 /config/development/
-
+.env
+langs.php

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Phalcon Link - A (manual) URL shortener for Phalcon sites
 This is a very simple application that allows for URL redirection, using the phalcon.link domain. 
 
 The purpose of this application is not only to shorten various URLs that Phalcon uses, but also to showcase how easy it is to create a fully functional and lightweight application with 50 lines.
+
+### Deploy
+- $`./deploy.sh`

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 echo "Preparing Deploy"
-echo "Attempting to Update Langs File"
-
 export $(cat .env | xargs)
+
+echo "Fetching and updating from $GIT_REMOTE/$GIT_HEAD"
+git fetch $GIT_REMOTE
+git checkout --force ${GIT_REMOTE}/${GIT_HEAD}
+git reset --hard ${GIT_REMOTE}/${GIT_HEAD}
+
+echo "Attempting to Update Langs File"
 $(which php) util/update_langs.php

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Preparing Deploy"
+echo "Attempting to Update Langs File"
+
+export $(cat .env | xargs)
+$(which php) util/update_langs.php

--- a/index.php
+++ b/index.php
@@ -4,6 +4,8 @@ define("PLATFORM", "platform");
 define("LANG", "lang");
 define("PLATFORM_UNSET", "platform unset");
 
+$langs = require_once 'langs.php';
+
 $routes = [
     'about'                                => 'https://phalconphp.com/en/about',
     'blog'                                 => 'https://blog.phalconphp.com',
@@ -115,10 +117,6 @@ EOF;
     return $app->response->send();
 };
 
-$verifyUrl = function ($url) use ($routes) {
-    return array_key_exists($url, $routes);
-};
-
 $platformUrlBuilder = function ($url, $platform, $category, $version) use ($verifyUrl, $routes) {
     switch ($url) {
         case 'download':
@@ -140,18 +138,16 @@ $platformUrlBuilder = function ($url, $platform, $category, $version) use ($veri
             $url = sprintf('team/%s', $platform);
             break;
     }
-    return $verifyUrl($url) ? $routes[$url] : $routes['default'];
+    return $routes[$url] ?? $routes['default'];
 };
 
 $langUrlBuilder = function ($url, $platform) use ($verifyUrl, $routes) {
-    if ($verifyUrl($url)) {
+    if (isset($routes[$url])) {
         return $routes[$url] . "/" . $platform;
     } else {
         return $routes['default'];
     }
 };
-
-$langs = ['ar', 'bg', 'bs', 'cs', 'de', 'el', 'en', 'es', 'fr', 'hr', 'hu', 'id', 'ja', 'pl', 'pt', 'ro', 'ru', 'tr', 'uk', 'vi', 'zh'];
 
 $resolvePlatformOrLang = function ($platformOrLang) use ($langs) {
     if (isset($platformOrLang)) {

--- a/langs.php.sample
+++ b/langs.php.sample
@@ -1,0 +1,26 @@
+<?php
+
+# FILE GENERATED AUTOMATICALLY CHANGES WILL NOT BE MAINTAINED
+# RUN $ ./deploy TO REGENERATE
+return array (
+  0 => 'ar',
+  1 => 'bs',
+  2 => 'bg',
+  3 => 'zh-CN',
+  4 => 'hr',
+  5 => 'cs',
+  6 => 'fr',
+  7 => 'de',
+  8 => 'el',
+  9 => 'hu',
+  10 => 'id',
+  11 => 'ja',
+  12 => 'pl',
+  13 => 'pt-PT',
+  14 => 'ro',
+  15 => 'ru',
+  16 => 'es-ES',
+  17 => 'tr',
+  18 => 'uk',
+  19 => 'vi',
+);

--- a/util/update_langs.php
+++ b/util/update_langs.php
@@ -53,4 +53,8 @@ try {
 } catch (Exception $e) {
   echo $e->getMessage() . PHP_EOL;
   echo $e->getTraceAsString(). PHP_EOL;
+  print_r('Langs could not be retrieved please review errors.' . PHP_EOL .
+    'Previous Langs should have been untouched but a backup was made at' . PHP_EOL .
+    'langs.php.bak for your convenience' . PHP_EOL
+  );
 }

--- a/util/update_langs.php
+++ b/util/update_langs.php
@@ -1,0 +1,46 @@
+<?php
+
+$url = 'https://api.crowdin.com/api/project/phalcon-documentation/status?key=' . getenv('CROWDIN_KEY');
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, ['json' => 1]);
+
+try {
+  $result = curl_exec($ch);
+  if (curl_errno($ch)) {
+    throw new Exception(curl_error($ch));
+  }
+  curl_close($ch);
+
+  print_r('Successfully Contacted Crowdin' . PHP_EOL);
+
+  $json = json_decode($result);
+
+  if (isset($json->success) && !$json->success) {
+    throw new Exception($json->error->message);
+  }
+
+  print_r('Recieved Successful Response from Crowdin' . PHP_EOL);
+
+  $langs = [];
+  foreach ($json as $lang) {
+    $langs[] = $lang->code;
+  }
+
+  $langs_code = 'return ' . var_export($langs, true) . ';';
+
+  unlink('langs.php');
+  $fp = fopen('langs.php', 'w');
+  fwrite($fp, '<?php');
+  fwrite($fp, PHP_EOL . PHP_EOL);
+  fwrite($fp, '# FILE GENERATED AUTOMATICALLY CHANGES WILL NOT BE MAINTAINED' . PHP_EOL);
+  fwrite($fp, '# RUN $ ./deploy TO REGENERATE' . PHP_EOL);
+  fwrite($fp, $langs_code . PHP_EOL);
+  fclose($fp);
+} catch (Exception $e) {
+  echo $e->getMessage() . PHP_EOL;
+  echo $e->getTraceAsString(). PHP_EOL;
+}

--- a/util/update_langs.php
+++ b/util/update_langs.php
@@ -9,6 +9,11 @@ curl_setopt($ch, CURLOPT_POST, true);
 curl_setopt($ch, CURLOPT_POSTFIELDS, ['json' => 1]);
 
 try {
+  if(file_exists('langs.php')) {
+    print_r('Creating backup of existing langs.php called langs.php.bak' . PHP_EOL);
+    copy('langs.php', 'langs.php.bak');
+  }
+
   $result = curl_exec($ch);
   if (curl_errno($ch)) {
     throw new Exception(curl_error($ch));
@@ -40,6 +45,11 @@ try {
   fwrite($fp, '# RUN $ ./deploy TO REGENERATE' . PHP_EOL);
   fwrite($fp, $langs_code . PHP_EOL);
   fclose($fp);
+
+  if(file_exists('langs.php.bak')) {
+    print_r('Removing old langs.php.bak' . PHP_EOL);
+    unlink('langs.php.bak');
+  }
 } catch (Exception $e) {
   echo $e->getMessage() . PHP_EOL;
   echo $e->getTraceAsString(). PHP_EOL;


### PR DESCRIPTION
###### Closes https://github.com/phalcon/docs/issues/1003
#### What am I?

Link did not provide a way to pass a second URL argument that is a 2 char language abbreviation.
This adds a check which can identify available languages and switch the context to supply the language in place of the platform.

Existing behavior is maintained and any language will direct to the base path plus the lang.

#### Manual Testing
- $`php -S 0.0.0.0:8000 -t . index.php`
- open `0.0.0.0:8000/?_url=/docs/ru` will direct to `docs.phalcon.com/ru/3.2`
- open `http://0.0.0.0:8000/?_url=/download/windows/latest/x86-70` will direct to `github.com/phalcon/cphalcon/releases/tag/v3.2.2`